### PR TITLE
Use RFC 4648 compliant Base64

### DIFF
--- a/lib/occi/cli/occi_opts.rb
+++ b/lib/occi/cli/occi_opts.rb
@@ -163,6 +163,10 @@ occi --endpoint https://localhost:3300/ --action delete --resource /compute/65sd
                 "--resource RESOURCE",
                 String,
                 "Resource to be queried (e.g. network, compute, storage etc.), required") do |resource|
+          # TODO: find a way to remove this OCCI-OS compatibility hack
+          resource = 'os_tpl' if resource == 'os'
+          resource = 'resource_tpl' if resource == 'resource'
+
           options.resource = resource
         end
 


### PR DESCRIPTION
New lines, in general, tend to cause parsing issues and Base64 is valid even without them ... 
